### PR TITLE
Two fixes regarding plugin management

### DIFF
--- a/core.c
+++ b/core.c
@@ -65,6 +65,32 @@ int get_new_request_id()
 
 
 /**
+ * Specific initialisation done only once in proxenet whole process.
+ * 
+ * @note Only useful for Perl's plugins right now.
+ */
+void proxenet_init_once_plugins(int argc, char** argv, char** envp)
+{
+#ifdef _PERL_PLUGIN
+	proxenet_perl_preinitialisation(argc, argv, envp);
+#endif
+}
+
+
+/**
+ * Specific delete/cleanup done only once in proxenet whole process.
+ * 
+ * @note Only useful for Perl's plugins right now.
+ */
+void proxenet_delete_once_plugins()
+{
+#ifdef _PERL_PLUGIN
+	proxenet_perl_postdeletion();
+#endif
+}
+
+
+/**
  *
  */
 void proxenet_initialize_plugins()
@@ -672,7 +698,6 @@ void kill_zombies()
  */
 int proxenet_init_plugins() 
 {
-		
 	if(proxenet_create_list_plugins(cfg->plugins_path) < 0) {
 		xlog(LOG_ERROR, "%s\n", "Failed to build plugins list, leaving");
 		return -1;
@@ -861,6 +886,8 @@ void xloop(sock_t sock)
 					}
 					
 					proxenet_state = SLEEPING;
+					
+					proxenet_destroy_plugins_vm();
 					proxenet_delete_list_plugins();
 					
 					if( proxenet_init_plugins() < 0) {
@@ -871,7 +898,6 @@ void xloop(sock_t sock)
 						break;
 					}
 
-					proxenet_destroy_plugins_vm();
 					proxenet_initialize_plugins();
 					
 					proxenet_state = ACTIVE;

--- a/core.h
+++ b/core.h
@@ -31,6 +31,9 @@ unsigned long 	active_threads_bitmask;
 sem_t 		tty_semaphore;
 plugin_t 	*plugins_list;  /* points to first plugin */
 
+
+void proxenet_init_once_plugins(int, char**, char**);
+void proxenet_delete_once_plugins();
 int 		proxenet_start(); 
 
 #endif /* _CORE_H */

--- a/main.c
+++ b/main.c
@@ -277,11 +277,20 @@ int main (int argc, char **argv, char** envp)
 	
 	tty_open();
 	
+	
+	/* perform plugin pre-initialisation */
+	proxenet_init_once_plugins(argc, argv, envp);
+	
+	
 	/* proxenet starts here  */
 	
 	retcode = proxenet_start(); 
 	
 	/* proxenet ends here */
+	
+	/* perform plugin post-deletion */
+	proxenet_delete_once_plugins();
+	
 end:
 	tty_close();
 

--- a/plugin-perl.c
+++ b/plugin-perl.c
@@ -37,8 +37,8 @@ int proxenet_perl_load_file(plugin_t* plugin)
 #ifdef DEBUG
 	xlog(LOG_DEBUG, "[Perl] Loading '%s'\n", pathname);
 #endif
-		
-	args[0] = "";	
+	
+	args[0] = "";
 	args[1] = pathname;
 	perl_parse(my_perl, NULL, 2, args, NULL);
 
@@ -55,19 +55,19 @@ int proxenet_perl_initialize_vm(plugin_t* plugin)
 	interpreter = plugin->interpreter;
 	
 	/* checks */
-	if (!interpreter->ready){	
+	if (!interpreter->ready){
 
 #ifdef DEBUG
 		xlog(LOG_DEBUG, "[Perl] %s\n", "Initializing VM");
 #endif
-	
+		
 		/* vm init */
 		my_perl = perl_alloc();
 		perl_construct(my_perl);
 		PL_exit_flags |= PERL_EXIT_DESTRUCT_END;
 
 		if (!my_perl) {
-			xlog(LOG_ERROR, "[Perl ]%s\n", "failed init-ing vm");
+			xlog(LOG_ERROR, "[Perl] %s\n", "failed init-ing vm");
 			return -1;
 		}
 
@@ -92,7 +92,6 @@ int proxenet_perl_destroy_vm(plugin_t* plugin)
 	
 	perl_destruct(my_perl);
         perl_free(my_perl);
-	PERL_SYS_TERM();
 
 	plugin->interpreter->vm = NULL;
 	plugin->interpreter->ready = false;
@@ -186,5 +185,24 @@ char* proxenet_perl_plugin(plugin_t* plugin, long rid, char* request, int type)
 
 	return buf;
 }
+
+
+/**
+ * 
+ */
+void proxenet_perl_preinitialisation(int argc, char** argv, char** envp)
+{
+	PERL_SYS_INIT3(&argc, &argv, &envp);
+}
+
+
+/**
+ * 
+ */
+void proxenet_perl_postdeletion()
+{
+	PERL_SYS_TERM();
+}
+
 
 #endif /* _PERL_PLUGIN */

--- a/plugin-perl.h
+++ b/plugin-perl.h
@@ -8,5 +8,7 @@ char* proxenet_perl_execute_function(plugin_t*, const char*, long, char*);
 void proxenet_perl_lock_vm(interpreter_t*);
 void proxenet_perl_unlock_vm(interpreter_t*);
 char* proxenet_perl_plugin(plugin_t*, long, char*, int);
+void proxenet_perl_preinitialisation(int argc, char** argv, char** envp);
+void proxenet_perl_postdeletion();
 
 #endif

--- a/plugin.c
+++ b/plugin.c
@@ -39,7 +39,7 @@ void proxenet_add_plugin(char* name, supported_plugins_t type, short priority)
 	plugin_t *plugin;
 	
 	plugin 			= (plugin_t*)proxenet_xmalloc(sizeof(plugin_t));
-	plugin->id 		= proxenet_plugin_list_size(plugins_list) + 1;
+	plugin->id 		= proxenet_plugin_list_size() + 1;
 	plugin->filename 	= strdup(name);
 	plugin->name		= get_plugin_basename(name, type);
 	plugin->type		= type;
@@ -123,6 +123,9 @@ void proxenet_delete_list_plugins()
 		proxenet_xfree(p);
 		p = next;
 	}
+	
+	plugins_list = NULL;
+	xlog(LOG_DEBUG, "%s\n", "Deleted all plugins");
 }
 
 


### PR DESCRIPTION
Fixed plugin reload use-after-free

  There was a use-after-free bug due to plugin_list not being re-initialized - to NULL - once the plugin list is entirely freed.

Fixed perl VM double-termination (through PERL_SYS_TERM()'s double-call)

  PERL_SYS_TERM() was called at each perl-plugin reload (using the `r' key) whereas perlembed(1) precising the following:
"The macros PERL_SYS_INIT3() and PERL_SYS_TERM() provide system-specific tune up of the C runtime environment necessary to run Perl interpreters; they should only be called once regardless of how many interpreters you create or destroy".
  PERL_SYS_INIT3() was also added in this commit, it shouldn't be a problem there called once there.

Open to discussion :)
