### PR TITLE
Fixed some compiler warnings in socks.c

### DIFF
--- a/socks.c
+++ b/socks.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <sys/socket.h>
+#include <string.h>
 
 #include "socket.h"
 #include "utils.h"


### PR DESCRIPTION
There were warnings from compiler regarding memcpy and other functions.
Adding <string.h> header solves all the warnings. 